### PR TITLE
Remove unused overview in right sidebar

### DIFF
--- a/src/components/RightSidebar/index.tsx
+++ b/src/components/RightSidebar/index.tsx
@@ -20,7 +20,13 @@ const RightSidebar = () => {
       <Box flex="1" overflow="scroll">
         <Accordion.Root multiple defaultValue={["0"]}>
           <Accordion.Item value="0">
-            <Accordion.ItemTrigger cursor="pointer" px={6}>
+            <Accordion.ItemTrigger
+              cursor="pointer"
+              px={6}
+              display="flex"
+              justifyContent="space-between"
+              alignItems="center"
+            >
               <SidebarSectionHeading>Selected Indicators</SidebarSectionHeading>
               <Accordion.ItemIndicator />
             </Accordion.ItemTrigger>


### PR DESCRIPTION
Removes unused "Overview" section in right sidebar.

Temporary fix until we determine what should be included in this section.
<img width="455" height="1276" alt="image" src="https://github.com/user-attachments/assets/0991f06d-ef8c-49f3-848a-8087d78cf7a6" />
