### PR TITLE
Use PMTilesDatasets endpoint instead of hardcoded list

### DIFF
--- a/src/components/Map/PMTilesLayers.tsx
+++ b/src/components/Map/PMTilesLayers.tsx
@@ -43,7 +43,7 @@ function PMTilesMapLayer({ id }: PMTilesMapLayerProps) {
       "line-opacity": opacity,
     },
     source: layerId,
-    "source-layer": "shorelines_annual",
+    "source-layer": metadata?.source_layer || "",
     filter: ["==", "year", Number(year)],
   };
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -26,6 +26,7 @@ export interface BaseDataset {
   filename_id?: string;
   titiler_url_params?: string;
   url?: string;
+  source_layer?: string;
 }
 
 export interface TabularDataset extends BaseDataset {


### PR DESCRIPTION
@LanesGood I've fixed the problem with the Coastlines showing in all clusters. Note that there isn't coastlines data for 2024.